### PR TITLE
Update to Vello 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ categories = ["gui", "graphics", "rendering", "virtualization", "rendering::engi
 keywords = ["ui", "gui", "interface", "graphics", "user-interface"]
 
 [workspace.dependencies]
-peniko = "0.2.0"
+bytemuck = "1.21.0"
+peniko = "0.3.1"
 nalgebra = { version = "0.33.2", default-features = false, features = ["std"] }
 indexmap = "2.7.0"
 maycoon-core = { version = "0.1.0", path = "maycoon-core" }

--- a/examples/canvas/src/main.rs
+++ b/examples/canvas/src/main.rs
@@ -1,5 +1,5 @@
 use maycoon::color::kurbo::{Affine, Circle, Point, Stroke};
-use maycoon::color::{Brush, Color};
+use maycoon::color::{color::palette, Brush};
 use maycoon::core::app::MayApp;
 use maycoon::core::config::MayConfig;
 use maycoon::macros::State;
@@ -15,7 +15,7 @@ fn main() {
             scene.stroke(
                 &Stroke::new(10.0),
                 Affine::default(),
-                &Brush::Solid(Color::GREEN),
+                &Brush::Solid(palette::css::GREEN),
                 None,
                 &Circle::new(Point::new(100.0, 100.0), 50.0),
             );

--- a/examples/image/src/main.rs
+++ b/examples/image/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
         Image::new(ImageData::new(
             image_data.clone(),
             Vector2::new(427, 640),
-            peniko::Format::Rgba8,
+            peniko::ImageFormat::Rgba8,
         )),
     )
 }

--- a/maycoon-core/Cargo.toml
+++ b/maycoon-core/Cargo.toml
@@ -10,8 +10,8 @@ keywords.workspace = true
 
 [dependencies]
 winit = "0.30.7"
-wgpu-types = "22.0.0"
-vello = "0.3.0"
+wgpu-types = "23.0.0"
+vello = "0.4.0"
 taffy = "0.7.1"
 bitflags = "2.6.0"
 font-kit = "0.14.2"
@@ -20,10 +20,11 @@ maycoon-theme = { workspace = true }
 nalgebra = { workspace = true }
 indexmap = { workspace = true }
 peniko = { workspace = true }
+skrifa = "0.26.4"
 
 [features]
 default = []
 
-# Re-exports `vello` for drawing vector graphics.
+# Re-exports `skrifa` and `vello` for drawing vector graphics.
 # Required if you want to make custom widgets or draw vector graphics.
 vg = []

--- a/maycoon-core/src/lib.rs
+++ b/maycoon-core/src/lib.rs
@@ -7,6 +7,9 @@
 #[cfg(feature = "vg")]
 pub use vello as vg;
 
+#[cfg(feature = "vg")]
+pub use skrifa;
+
 /// Contains useful types for interacting with winit.
 pub mod window {
     pub use winit::event::*;

--- a/maycoon-theme/src/style.rs
+++ b/maycoon-theme/src/style.rs
@@ -171,7 +171,7 @@ impl Default for Style {
 }
 
 /// Default widget styles.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct DefaultStyles {
     text: DefaultTextStyles,
     container: DefaultContainerStyles,
@@ -209,7 +209,7 @@ impl DefaultStyles {
 }
 
 /// The default text widget styles.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct DefaultTextStyles {
     foreground: Color,
     background: Color,
@@ -236,7 +236,7 @@ impl DefaultTextStyles {
 }
 
 /// The default container widget styles.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct DefaultContainerStyles {
     foreground: Color,
     background: Color,
@@ -263,7 +263,7 @@ impl DefaultContainerStyles {
 }
 
 /// The default interactive widget styles.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct DefaultInteractiveStyles {
     active: Color,
     inactive: Color,

--- a/maycoon-theme/src/theme/celeste.rs
+++ b/maycoon-theme/src/theme/celeste.rs
@@ -1,4 +1,4 @@
-use peniko::Color;
+use peniko::{color::palette, Color};
 
 use crate::globals::Globals;
 use crate::id::WidgetId;
@@ -27,44 +27,47 @@ impl Theme for CelesteTheme {
         match id.namespace() {
             "maycoon-widgets" => match id.id() {
                 "Text" => Some(Style::from_values([
-                    ("color".to_string(), StyleVal::Color(Color::BLACK)),
-                    ("color_invert".to_string(), StyleVal::Color(Color::WHITE)),
+                    ("color".to_string(), StyleVal::Color(palette::css::BLACK)),
+                    (
+                        "color_invert".to_string(),
+                        StyleVal::Color(palette::css::WHITE),
+                    ),
                 ])),
 
                 "Button" => Some(Style::from_values([
                     (
                         "color_idle".to_string(),
-                        StyleVal::Color(Color::rgb8(150, 170, 250)),
+                        StyleVal::Color(Color::from_rgb8(150, 170, 250)),
                     ),
                     (
                         "color_pressed".to_string(),
-                        StyleVal::Color(Color::rgb8(130, 150, 230)),
+                        StyleVal::Color(Color::from_rgb8(130, 150, 230)),
                     ),
                     (
                         "color_hovered".to_string(),
-                        StyleVal::Color(Color::rgb8(140, 160, 240)),
+                        StyleVal::Color(Color::from_rgb8(140, 160, 240)),
                     ),
                 ])),
 
                 "Checkbox" => Some(Style::from_values([
                     (
                         "color_checked".to_string(),
-                        StyleVal::Color(Color::rgb8(130, 130, 230)),
+                        StyleVal::Color(Color::from_rgb8(130, 130, 230)),
                     ),
                     (
                         "color_unchecked".to_string(),
-                        StyleVal::Color(Color::rgb8(170, 170, 250)),
+                        StyleVal::Color(Color::from_rgb8(170, 170, 250)),
                     ),
                 ])),
 
                 "Slider" => Some(Style::from_values([
                     (
                         "color".to_string(),
-                        StyleVal::Color(Color::rgb8(130, 130, 230)),
+                        StyleVal::Color(Color::from_rgb8(130, 130, 230)),
                     ),
                     (
                         "color_ball".to_string(),
-                        StyleVal::Color(Color::rgb8(170, 170, 250)),
+                        StyleVal::Color(Color::from_rgb8(170, 170, 250)),
                     ),
                 ])),
 
@@ -76,13 +79,13 @@ impl Theme for CelesteTheme {
 
     fn defaults(&self) -> DefaultStyles {
         DefaultStyles::new(
-            DefaultTextStyles::new(Color::BLACK, Color::WHITE_SMOKE),
-            DefaultContainerStyles::new(Color::ANTIQUE_WHITE, Color::WHITE),
+            DefaultTextStyles::new(palette::css::BLACK, palette::css::WHITE_SMOKE),
+            DefaultContainerStyles::new(palette::css::ANTIQUE_WHITE, palette::css::WHITE),
             DefaultInteractiveStyles::new(
-                Color::rgb8(130, 150, 230),
-                Color::rgb8(150, 170, 250),
-                Color::rgb8(140, 160, 240),
-                Color::rgb8(110, 110, 110),
+                Color::from_rgb8(130, 150, 230),
+                Color::from_rgb8(150, 170, 250),
+                Color::from_rgb8(140, 160, 240),
+                Color::from_rgb8(110, 110, 110),
             ),
         )
     }

--- a/maycoon-widgets/Cargo.toml
+++ b/maycoon-widgets/Cargo.toml
@@ -11,6 +11,7 @@ keywords.workspace = true
 [dependencies]
 maycoon-theme = { workspace = true }
 maycoon-core = { workspace = true, features = ["vg"] }
+bytemuck = { workspace = true }
 nalgebra = { workspace = true }
 
 [features]

--- a/maycoon-widgets/src/image.rs
+++ b/maycoon-widgets/src/image.rs
@@ -4,7 +4,7 @@ use maycoon_core::app::update::Update;
 use maycoon_core::layout::{LayoutNode, LayoutStyle, StyleNode};
 use maycoon_core::state::{State, Val};
 use maycoon_core::vg::kurbo::{Affine, Vec2};
-use maycoon_core::vg::peniko::{Blob, Format};
+use maycoon_core::vg::peniko::{Blob, ImageFormat};
 use maycoon_core::vg::{peniko, Scene};
 use maycoon_core::widget::Widget;
 use maycoon_theme::id::WidgetId;
@@ -103,12 +103,12 @@ impl<S: State> Widget<S> for Image<S> {
 pub struct ImageData {
     image: Vec<u8>,
     size: Vector2<u32>,
-    format: Format,
+    format: ImageFormat,
 }
 
 impl ImageData {
     /// Creates a new [ImageData] from the image itself, its size and the image format.
-    pub fn new(image: Vec<u8>, size: Vector2<u32>, format: Format) -> Self {
+    pub fn new(image: Vec<u8>, size: Vector2<u32>, format: ImageFormat) -> Self {
         Self {
             image,
             size,

--- a/maycoon-widgets/src/text.rs
+++ b/maycoon-widgets/src/text.rs
@@ -2,12 +2,12 @@ use crate::ext::WidgetLayoutExt;
 use maycoon_core::app::info::AppInfo;
 use maycoon_core::app::update::Update;
 use maycoon_core::layout::{Dimension, LayoutNode, LayoutStyle, StyleNode};
+use maycoon_core::skrifa::instance::Size;
+use maycoon_core::skrifa::raw::FileRef;
+use maycoon_core::skrifa::setting::VariationSetting;
+use maycoon_core::skrifa::MetadataProvider;
 use maycoon_core::state::{State, Val};
 use maycoon_core::vg::peniko::{Brush, Fill};
-use maycoon_core::vg::skrifa::instance::Size;
-use maycoon_core::vg::skrifa::raw::FileRef;
-use maycoon_core::vg::skrifa::setting::VariationSetting;
-use maycoon_core::vg::skrifa::MetadataProvider;
 use maycoon_core::vg::{peniko, Glyph, Scene};
 use maycoon_core::widget::Widget;
 use maycoon_theme::id::WidgetId;
@@ -144,7 +144,7 @@ impl<S: State> Widget<S> for Text<S> {
             .draw_glyphs(&font)
             .font_size(font_size)
             .brush(&Brush::Solid(color))
-            .normalized_coords(location.coords())
+            .normalized_coords(bytemuck::cast_slice(location.coords()))
             .hint(hinting)
             .draw(
                 &peniko::Style::Fill(Fill::NonZero),


### PR DESCRIPTION
* Also update to Peniko 0.3.1 and wgpu-types 23.
* Vello no longer re-exports `skrifa` since it has no public usage within the Vello API any longer. Depend on skrifa directly here and re-export it next to `vg` when the `vg` feature is enabled.
* The normalized coords for Vello no longer use a Skrifa type directly, so a `bytemuck::cast_slice` is required.
* `peniko::Color` is now powered by the `color` crate which is a much improved color library over what was in Peniko before. However, the `Color` type no longer implements `Default`, `Hash` or some other things, so don't auto-derive all of those for the various style structs.
* Named colors are available via a `palette::css` module rather than as associated constants on the `Color` type.
* `peniko::Format` was renamed to `ImageFormat`.