### PR TITLE
Fix more `clippy::doc_markdown` lints

### DIFF
--- a/maycoon-core/src/app/font_ctx.rs
+++ b/maycoon-core/src/app/font_ctx.rs
@@ -33,12 +33,12 @@ impl FontContext {
         Some(())
     }
 
-    /// Get a font by a specified name. Returns [None] if the font could not be found.
+    /// Get a font by a specified name. Returns [`None`] if the font could not be found.
     pub fn get(&self, name: impl ToString) -> Option<Font> {
         self.fonts.get(&name.to_string()).cloned()
     }
 
-    /// Removes a font. Returns [None] if the font does not exist.
+    /// Removes a font. Returns [`None`] if the font does not exist.
     pub fn remove(&mut self, name: impl ToString) -> Option<()> {
         self.fonts.swap_remove(&name.to_string()).map(|_| ())
     }

--- a/maycoon-core/src/app/info.rs
+++ b/maycoon-core/src/app/info.rs
@@ -6,7 +6,7 @@ use crate::app::font_ctx::FontContext;
 
 /// The application information container.
 pub struct AppInfo {
-    /// The position of the cursor. If [None], the cursor left the window.
+    /// The position of the cursor. If [`None`], the cursor left the window.
     pub cursor_pos: Option<Vector2<f64>>,
     /// The fired key events.
     pub keys: Vec<(DeviceId, KeyEvent)>,

--- a/maycoon-theme/src/style.rs
+++ b/maycoon-theme/src/style.rs
@@ -74,12 +74,12 @@ impl Style {
         self.map.insert(name.to_string(), StyleVal::UInt(value));
     }
 
-    /// Get a style value by name. Returns [None] if the value name does not exist.
+    /// Get a style value by name. Returns [`None`] if the value name does not exist.
     pub fn get(&self, name: impl ToString) -> Option<StyleVal> {
         self.map.get(&name.to_string()).cloned()
     }
 
-    /// Get a color style value by name. Returns [None] if the value name does not exist.
+    /// Get a color style value by name. Returns [`None`] if the value name does not exist.
     pub fn get_color(&self, name: impl ToString) -> Option<Color> {
         if let Some(val) = self.map.get(&name.to_string()) {
             match val {
@@ -91,7 +91,7 @@ impl Style {
         }
     }
 
-    /// Get a gradient style value by name. Returns [None] if the value name does not exist.
+    /// Get a gradient style value by name. Returns [`None`] if the value name does not exist.
     pub fn get_gradient(&self, name: impl ToString) -> Option<Gradient> {
         if let Some(val) = self.map.get(&name.to_string()) {
             match val {
@@ -103,7 +103,7 @@ impl Style {
         }
     }
 
-    /// Get a brush style value by name. Returns [None] if the value name does not exist.
+    /// Get a brush style value by name. Returns [`None`] if the value name does not exist.
     pub fn get_brush(&self, name: impl ToString) -> Option<Brush> {
         if let Some(val) = self.map.get(&name.to_string()) {
             match val {
@@ -115,7 +115,7 @@ impl Style {
         }
     }
 
-    /// Get a float style value by name. Returns [None] if the value name does not exist.
+    /// Get a float style value by name. Returns [`None`] if the value name does not exist.
     pub fn get_float(&self, name: impl ToString) -> Option<f32> {
         if let Some(val) = self.map.get(&name.to_string()) {
             match val {
@@ -127,7 +127,7 @@ impl Style {
         }
     }
 
-    /// Get an int style value by name. Returns [None] if the value name does not exist.
+    /// Get an int style value by name. Returns [`None`] if the value name does not exist.
     pub fn get_int(&self, name: impl ToString) -> Option<i32> {
         if let Some(val) = self.map.get(&name.to_string()) {
             match val {
@@ -139,7 +139,7 @@ impl Style {
         }
     }
 
-    /// Get an unsized int style value by name. Returns [None] if the value name does not exist.
+    /// Get an unsized int style value by name. Returns [`None`] if the value name does not exist.
     pub fn get_uint(&self, name: impl ToString) -> Option<u32> {
         if let Some(val) = self.map.get(&name.to_string()) {
             match val {
@@ -151,7 +151,7 @@ impl Style {
         }
     }
 
-    /// Get a bool style value by name. Returns [None] if the value name does not exist.
+    /// Get a bool style value by name. Returns [`None`] if the value name does not exist.
     pub fn get_bool(&self, name: impl ToString) -> Option<bool> {
         if let Some(val) = self.map.get(&name.to_string()) {
             match val {

--- a/maycoon-widgets/src/checkbox.rs
+++ b/maycoon-widgets/src/checkbox.rs
@@ -58,7 +58,7 @@ impl<S: State> Checkbox<S> {
 
     /// Sets the value of the checkbox and returns itself.
     ///
-    /// The [Val] should be state dependent, so you can mutate it on change.
+    /// The [`Val`] should be state dependent, so you can mutate it on change.
     pub fn with_value(mut self, value: impl Into<Val<S, bool>>) -> Self {
         self.value = value.into();
         self

--- a/maycoon-widgets/src/fetcher.rs
+++ b/maycoon-widgets/src/fetcher.rs
@@ -22,7 +22,7 @@ use std::sync::{Arc, Mutex};
 /// ### Workflow of a [`WidgetFetcher`].
 /// 1. Run the task in the background using the [`TaskRunner`](maycoon_core::tasks::runner::TaskRunner).
 /// 2. Construct the widget with [`None`] as the result (task is still loading).
-/// 3. Once the task is done, update the UI with the new result and trigger an [Update].
+/// 3. Once the task is done, update the UI with the new result and trigger an [`Update`].
 ///
 /// ### Theming
 /// The widget itself only draws the underlying widget, so theming is useless.

--- a/maycoon-widgets/src/icon.rs
+++ b/maycoon-widgets/src/icon.rs
@@ -16,10 +16,10 @@ pub use usvg::ImageRendering;
 pub use usvg::ShapeRendering;
 pub use usvg::TextRendering;
 
-/// Error type for parsing SVGs with [usvg].
+/// Error type for parsing SVGs with [`usvg`].
 pub type SvgError = usvg::Error;
 
-/// A simple icon widget to display SVG icons using [vello_svg] and [usvg].
+/// A simple icon widget to display SVG icons using [`vello_svg`] and [`usvg`].
 ///
 /// ### Theming
 /// The widget itself only draws the underlying icon, so theming is useless.
@@ -89,17 +89,17 @@ impl<S: State> WidgetLayoutExt<S> for Icon<S> {
     }
 }
 
-/// An SVG icon rendered as a vello [Scene].
+/// An SVG icon rendered as a Vello [`Scene`].
 pub struct SvgIcon(Scene);
 
 impl SvgIcon {
     /// Creates a new icon from the given SVG source.
-    /// Returns [Ok] if the SVG could be parsed, [Err] otherwise.
+    /// Returns [`Ok`] if the SVG could be parsed, [`Err`] otherwise.
     ///
-    /// **This calls [Self::new_custom] with the following options:**
-    /// - [ShapeRendering::GeometricPrecision] for precise shape rendering.
-    /// - [TextRendering::OptimizeLegibility] for good text rendering.
-    /// - [ImageRendering::OptimizeSpeed] for fast image rendering.
+    /// **This calls [`Self::new_custom`] with the following options:**
+    /// - [`ShapeRendering::GeometricPrecision`] for precise shape rendering.
+    /// - [`TextRendering::OptimizeLegibility`] for good text rendering.
+    /// - [`ImageRendering::OptimizeSpeed`] for fast image rendering.
     pub fn new(source: impl AsRef<str>) -> Result<Self, SvgError> {
         Self::new_custom(
             source,
@@ -110,7 +110,7 @@ impl SvgIcon {
     }
 
     /// Creates a new icon from the given SVG source.
-    /// Returns [Ok] if the SVG could be parsed, [Err] otherwise.
+    /// Returns [`Ok`] if the SVG could be parsed, [`Err`] otherwise.
     ///
     /// This method allows customizing the SVG rendering options.
     pub fn new_custom(
@@ -134,7 +134,7 @@ impl SvgIcon {
         Ok(Self(scene))
     }
 
-    /// Returns the underlying [Scene].
+    /// Returns the underlying [`Scene`].
     pub fn scene(&self) -> &Scene {
         &self.0
     }

--- a/maycoon-widgets/src/text.rs
+++ b/maycoon-widgets/src/text.rs
@@ -21,9 +21,9 @@ use nalgebra::Vector2;
 /// ### Theming
 /// You can style the text with the following properties:
 /// - `color` - The color of the text.
-/// - `color_invert` - The color to use when the `invert_color` property is set to `true` in the theme [Globals].
+/// - `color_invert` - The color to use when the `invert_color` property is set to `true` in the theme [`Globals`].
 ///
-/// [Globals]: maycoon_theme::globals::Globals
+/// [`Globals`]: maycoon_theme::globals::Globals
 pub struct Text<S: State> {
     style: Val<S, LayoutStyle>,
     text: Val<S, String>,


### PR DESCRIPTION
This also fixes some missing backticks that weren't picked up by the clippy lint.